### PR TITLE
Remove 'None' from log level lookups.

### DIFF
--- a/grails-app/controllers/io/xh/hoist/admin/LogLevelAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/LogLevelAdminController.groovy
@@ -17,14 +17,8 @@ class LogLevelAdminController extends RestController {
 
     static restTarget = LogLevel
 
-    protected void preprocessSubmit(JSONObject submit) {
-        if (submit.level == 'None') {
-            submit.level = null
-        }
-    }
-
     def lookupData() {
-            def levels =  ['None'] + LogLevel.LEVELS
+            def levels = LogLevel.LEVELS
             renderJSON (levels: levels)
     }
 }


### PR DESCRIPTION
Motivated by a request to not mark log level overrides as 'required' in our Hoist React rest forms, which would mark the field as invalid if null, which it was not.

However, if the comboField was handling a non-required field it would include a null option, redundantly providing both 'None' and 'null' as options in the case of log level overrides. Anselm suggested getting rid of 'None' as a lookup.

Sencha Apps will require a front end change for this to transition smoothly:

https://github.com/exhi/hoist-sencha/pull/54