### PR TITLE
Checkpoint on identity/auth/roles re-org

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-xhReleaseVersion=5.0-SNAPSHOT
+xhReleaseVersion=6.0-SNAPSHOT
 grailsVersion=3.3.8
 grailsAsyncVersion=3.3.2
 gormVersion=6.1.10.RELEASE

--- a/grails-app/controllers/io/xh/hoist/admin/UserAdminController.groovy
+++ b/grails-app/controllers/io/xh/hoist/admin/UserAdminController.groovy
@@ -9,15 +9,35 @@ package io.xh.hoist.admin
 
 import io.xh.hoist.BaseController
 import io.xh.hoist.security.Access
+import io.xh.hoist.user.BaseRoleService
 import io.xh.hoist.user.BaseUserService
 
 @Access(['HOIST_ADMIN'])
 class UserAdminController extends BaseController {
 
     BaseUserService userService
+    BaseRoleService roleService
 
-    def index(boolean activeOnly) {
+    def users(boolean activeOnly) {
         renderJSON(userService.list(activeOnly))
+    }
+
+    def roles() {
+        renderJSON(roleService.getAllRoleAssignments())
+    }
+
+    def rolesForUser(String user) {
+        renderJSON(
+            user: user,
+            roles: roleService.getRolesForUser(user)
+        )
+    }
+
+    def usersForRole(String role) {
+        renderJSON(
+            role: role,
+            users: roleService.getUsersForRole(role)
+        )
     }
 
 }

--- a/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
+++ b/grails-app/controllers/io/xh/hoist/impl/XhController.groovy
@@ -20,6 +20,7 @@ import io.xh.hoist.feedback.FeedbackService
 import io.xh.hoist.json.JSON
 import io.xh.hoist.pref.PrefService
 import io.xh.hoist.security.AccessAll
+import io.xh.hoist.security.BaseAuthenticationService
 import io.xh.hoist.user.BaseUserService
 import io.xh.hoist.track.TrackService
 import io.xh.hoist.util.Utils
@@ -27,20 +28,25 @@ import org.grails.web.json.JSONObject
 
 @AccessAll
 @CompileStatic
-class HoistImplController extends BaseController {
+class XhController extends BaseController {
 
-    TrackService trackService
-    PrefService prefService
+    BaseUserService userService
     ClientErrorService clientErrorService
     ConfigService configService
-    GridExportImplService gridExportImplService
     DashboardService dashboardService
     FeedbackService feedbackService
-    BaseUserService userService
+    GridExportImplService gridExportImplService
+    PrefService prefService
+    TrackService trackService
 
     //------------------------
     // Identity
     //------------------------
+    def authStatus() {
+        def user = identityService.getAuthUser(request)
+        renderJSON(authenticated: user != null)
+    }
+
     def getIdentity() {
         renderJSON(identityService.clientConfig)
     }
@@ -60,9 +66,18 @@ class HoistImplController extends BaseController {
         renderJSON(success: true)
     }
 
+
+    //------------------------
+    // Interactive auth
+    //------------------------
+    def login(String username, String password) {
+        def success = identityService.login(username, password)
+        renderJSON(success: success)
+    }
+
     def logout() {
-        identityService.logout()
-        renderJSON(success: true)
+        def success = identityService.logout()
+        renderJSON(success: success)
     }
 
 

--- a/grails-app/controllers/io/xh/hoist/security/AccessInterceptor.groovy
+++ b/grails-app/controllers/io/xh/hoist/security/AccessInterceptor.groovy
@@ -46,7 +46,7 @@ class AccessInterceptor {
         Access access = clazz.getAnnotation(Access)
         if (access) {
             HoistUser user = identityService.getUser()
-            if (user.roles.containsAll(access.value())) {
+            if (user.hasAllRoles(access.value())) {
                 return true
             }
         }

--- a/grails-app/services/io/xh/hoist/security/BaseAuthenticationService.groovy
+++ b/grails-app/services/io/xh/hoist/security/BaseAuthenticationService.groovy
@@ -14,22 +14,71 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 /**
- * Applications must define a concrete implementation of this service with the name 'AuthenticationService'
+ * Abstract base service for processing and confirming user authentications and evaluating incoming
+ * requests to determine if authentication is either complete or not required.
+ *
+ * Apps must define a concrete implementation of this service with the name 'AuthenticationService'.
  */
 @CompileStatic
 abstract class BaseAuthenticationService {
 
     IdentityService identityService
 
+    //-----------------------------------
+    // Core template methods for override
+    //-----------------------------------
     /**
-     * Remove any cached login information for this user, requiring explicit re-login.
-     * Some SSO-based implementations may be unable to do this, in which case an exception should be thrown.
+     * Perform authentication on this request.
+     *
+     * This method is called when a user starts a new session with the server.
+     * Implementations should call setUser() to indicate recognition of an authenticated user.
+     *
+     * Returns boolean, indicating whether the authentication is complete.
+     *
+     * If true and a user has been set the request will continue with the authorized user.
+     * If true and *no* user has been set the framework will throw a 401 Exception.
+     *
+     * If false returned no further action will be taken on the response.
+     * This layer will be assumed to be in the middle of a redirect or protocol based negotiation.
      */
-    void logout() {}
+    abstract protected boolean completeAuthentication(HttpServletRequest request, HttpServletResponse response)
+
 
     /**
-     * Call once on every request to ensure request is authenticated before passing through to rest of the framework.
-     * Not typically overridden. See completeAuthentication() for main entry point for implementing subclasses.
+     * Process an interactive username + password based login. App implementations supporting
+     * interactive login should return true if the user can be resolved and is authenticated.
+     *
+     * SSO-based implementations should leave this default implementation in place to indicate that
+     * interactive login is not supported.
+     */
+    boolean login(HttpServletRequest request, String username, String password) {
+        return false
+    }
+
+
+    /**
+     * Take any app-specific actions to remove cached login information for this user and
+     * require an explicit re-login. App implementations supporting interactive logout should return
+     * true if logout was either successfully completed or required no further action.
+     *
+     * Note that this method is called by IdentityService, which will clear the authenticated user
+     * from the session provided this method confirms logout from the application perspective.
+     *
+     * SSO-based implementations should leave this default implementation in place to indicate that
+     * interactive logout is not supported.
+     */
+    boolean logout() {
+        return false
+    }
+
+
+    //--------------------
+    // Implemented methods
+    //--------------------
+    /**
+     * Called once on every request to ensure request is authenticated before passing through to
+     * rest of the framework. Not typically overridden - see completeAuthentication() as main entry
+     * point for subclass implementation.
      */
     boolean allowRequest(HttpServletRequest request, HttpServletResponse response) {
         if (identityService.getAuthUser(request) || isWhitelist(request)) {
@@ -48,44 +97,42 @@ abstract class BaseAuthenticationService {
         return true
     }
 
-
-    //-----------------------------------
-    // Core template methods for override
-    //-----------------------------------
     /**
-     * Perform authentication on this request.
-     *
-     * This method is called when a user starts a new session with the server.
-     * Implementations should call setUser() to indicate recognition of an authenticated user.
-     *
-     * Returns boolean, indicating whether the authentication is complete.
-     *
-     * If true returned and a user has been set via setUser() the request will continue with the authorized user.
-     * If true and *no* user has been set the framework will throw a 401 Exception.
-     *
-     * If false returned no further action will be taken on the response.
-     * This layer will be assumed to be in the middle of a redirect or protocol based negotiation.
-     */
-    abstract protected boolean completeAuthentication(HttpServletRequest request, HttpServletResponse response)
-
-
-    //--------------------
-    // Implemented methods
-    //--------------------
-    /**
-     * Enumerate requests that do not require an authenticated user.
-     * Should be implemented in AuthenticationService and called with super to add app specific whitelisted requests
-     */
-    protected boolean isWhitelist(HttpServletRequest request) {
-        return request.requestURI == '/hoistImpl/version'
-    }
-
-    /**
-     * Set the authenticated user.
-     * Should be called by implementations of completeAuthentication() when user has been reliably determined.
+     * Set the authenticated user, to be called by implementations of completeAuthentication()
+     * when user has been reliably determined.
      */
     protected void setUser(HttpServletRequest request, HoistUser user) {
         identityService.noteUserAuthenticated(request, user)
     }
+
+    /**
+     * Identify requests that do not require an authenticated user. App AuthenticationServices can
+     * whitelist additional requests, but should call this superclass implementation to ensure
+     * required auth URIs are included.
+     */
+    protected boolean isWhitelist(HttpServletRequest request) {
+        def uri = request.requestURI
+        return whitelistURIs.contains(uri) || isWhitelistFile(uri)
+    }
+
+    protected boolean isWhitelistFile(String uri) {
+        whitelistFileExtensions.any{uri.endsWith(it)}
+    }
+
+    protected List<String> whitelistURIs = [
+        '/xh/authStatus',
+        '/xh/login',
+        '/xh/logout',
+        '/xh/version'
+    ]
+
+    protected List<String> whitelistFileExtensions = [
+        '.css',
+        '.ico',
+        '.jpg',
+        '.png',
+        '.woff',
+        '.woff2'
+    ]
 
 }

--- a/grails-app/services/io/xh/hoist/security/BaseAuthenticationService.groovy
+++ b/grails-app/services/io/xh/hoist/security/BaseAuthenticationService.groovy
@@ -119,6 +119,10 @@ abstract class BaseAuthenticationService {
         whitelistFileExtensions.any{uri.endsWith(it)}
     }
 
+    /**
+     * Full URIs that should not require authentication. These are Hoist endpoints called prior to
+     * or in the process of auth, or from which we wish to always return data.
+     */
     protected List<String> whitelistURIs = [
         '/xh/authStatus',
         '/xh/login',
@@ -126,11 +130,21 @@ abstract class BaseAuthenticationService {
         '/xh/version'
     ]
 
+    /**
+     * Extensions of file-based assets that do not require authentication and can be skipped for
+     * efficiency. Note that for Hoist React applications, the Grails server typically neither
+     * serves nor secures static assets, minimizing the impact of this list / need for tuning.
+      */
     protected List<String> whitelistFileExtensions = [
         '.css',
+        '.js',
+        '.gif',
         '.ico',
+        '.jpeg',
         '.jpg',
         '.png',
+        '.svg',
+        '.ttf',
         '.woff',
         '.woff2'
     ]

--- a/grails-app/services/io/xh/hoist/user/BaseRoleService.groovy
+++ b/grails-app/services/io/xh/hoist/user/BaseRoleService.groovy
@@ -27,27 +27,47 @@ import static java.util.Collections.emptyMap
  * Hoist has a requirement for only one special role - "HOIST_ADMIN" - which grants access to the
  * built-in admin functions and enables user impersonation via IdentityService.
  *
- * Note that the HoistUser getRoles() and hasRole() methods can serve as the primary application
- * entry-point for verifying roles on a given user, reducing or eliminating any need to call this
- * service directly.
+ * Note that the HoistUser `getRoles()` and `hasRole()` methods serve as the primary application
+ * entry-point for verifying roles on a given user, reducing or eliminating any need to call an
+ * implementation of this service directly.
  */
 @CompileStatic
 abstract class BaseRoleService extends BaseService {
 
     /**
      * Map of roles to assigned users.
-     * Applications should take care to provide an efficient / fast implementation.
+     *
+     * Applications should take care to provide an efficient / fast implementation as this can be
+     * queried multiple times when processing a request, and is deliberately not cached on the
+     * HoistUser object.
      */
     Map<String, Set<String>> getAllRoleAssignments() {
         return emptyMap()
     }
 
+    /**
+     * Return all roles assigned to a given user(name).
+     *
+     * Applications may wish to provide their own more efficient implementation as required,
+     * e.g. by pre-indexing role assignments by username vs. constructing dynamically.
+     *
+     * Note that this default implementation does not validate that the username provided is in
+     * fact an active and enabled application user as per UserService. Apps may wish to do so -
+     * the Hoist framework does not depend on it.
+     */
     Set<String> getRolesForUser(String username) {
         return allRoleAssignments
             .findAll{role, users -> users.contains(username)}
             .keySet()
     }
 
+    /**
+     * Return all users with a given role, as a simple list of usernames.
+     *
+     * Note that this default implementation does not validate that the usernames returned are in
+     * fact active and enabled application users as per UserService. Apps may wish to do so -
+     * the Hoist framework does not depend on it.
+     */
     Set<String> getUsersForRole(String role) {
         return allRoleAssignments[role] ?: new HashSet<String>()  // TODO - how to use emptySet here?
     }

--- a/grails-app/services/io/xh/hoist/user/BaseRoleService.groovy
+++ b/grails-app/services/io/xh/hoist/user/BaseRoleService.groovy
@@ -1,0 +1,55 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+package io.xh.hoist.user
+
+import groovy.transform.CompileStatic
+import io.xh.hoist.BaseService
+
+import static java.util.Collections.emptyMap
+
+/**
+ * Abstract base service for maintaining a list of HoistUser <-> role assignments, where roles
+ * are returned as simple strings and made available to both server and client code.
+ *
+ * Applications must define a concrete implementation of this service with the name 'RoleService'.
+ * Roles should be defined and sourced based on the app's particular needs.
+ *
+ * By way of example, implementations could:
+ *      + Query roles from a database, maintained by this app or externally.
+ *      + Query LDAP / AD group memberships, and resolve those to roles.
+ *      + Leverage configService to provide quick / built-in storage for role mappings.
+ *
+ * Hoist has a requirement for only one special role - "HOIST_ADMIN" - which grants access to the
+ * built-in admin functions and enables user impersonation via IdentityService.
+ *
+ * Note that the HoistUser getRoles() and hasRole() methods can serve as the primary application
+ * entry-point for verifying roles on a given user, reducing or eliminating any need to call this
+ * service directly.
+ */
+@CompileStatic
+abstract class BaseRoleService extends BaseService {
+
+    /**
+     * Map of roles to assigned users.
+     * Applications should take care to provide an efficient / fast implementation.
+     */
+    Map<String, Set<String>> getAllRoleAssignments() {
+        return emptyMap()
+    }
+
+    Set<String> getRolesForUser(String username) {
+        return allRoleAssignments
+            .findAll{role, users -> users.contains(username)}
+            .keySet()
+    }
+
+    Set<String> getUsersForRole(String role) {
+        return allRoleAssignments[role] ?: new HashSet<String>()  // TODO - how to use emptySet here?
+    }
+
+}

--- a/grails-app/services/io/xh/hoist/user/BaseUserService.groovy
+++ b/grails-app/services/io/xh/hoist/user/BaseUserService.groovy
@@ -11,10 +11,16 @@ import groovy.transform.CompileStatic
 import io.xh.hoist.BaseService
 
 /**
- * Applications must define a concrete implementation of this service with the name 'UserService'
+ * Abstract base service for maintaining a list of users for this application and (optionally) for
+ * the organization as a whole.
+ *
+ * Applications must define a concrete implementation of this service with the name 'UserService'.
+ *
+ * Note that calls to find() in particular are required to be inexpensive / fast to return, as
+ * they can be made multiple times with each request to resolve the authenticated user.
  */
 @CompileStatic
 abstract class BaseUserService extends BaseService {
-    abstract List<HoistUser> list(boolean activeOnly)
     abstract HoistUser find(String username)
+    abstract List<HoistUser> list(boolean activeOnly)
 }

--- a/grails-app/services/io/xh/hoist/user/IdentityService.groovy
+++ b/grails-app/services/io/xh/hoist/user/IdentityService.groovy
@@ -40,9 +40,6 @@ class IdentityService extends BaseService {
     TrackService trackService
 
 
-    //-----------------------------------
-    // Entry points for applications
-    //-----------------------------------
     /**
      * Return the current active user. Note that this is the 'apparent' user, used for most
      * application level purposes. In the case of an active impersonation session this will be
@@ -170,11 +167,8 @@ class IdentityService extends BaseService {
         return false
     }
 
-
-    //----------------------------------------
-    // Entry Point for AuthenticationService
-    //----------------------------------------
     /**
+     * Entry Point for AuthenticationService
      * Called by authenticationService when HoistUser has first been established for this session.
      */
     void noteUserAuthenticated(HttpServletRequest request, HoistUser user) {

--- a/src/main/groovy/io/xh/hoist/user/HoistUser.groovy
+++ b/src/main/groovy/io/xh/hoist/user/HoistUser.groovy
@@ -10,6 +10,7 @@ package io.xh.hoist.user
 import groovy.transform.CompileStatic
 import io.xh.hoist.json.JSONFormat
 import static io.xh.hoist.util.Utils.configService
+import static io.xh.hoist.util.Utils.roleService
 
 /**
  * Core user properties required for Hoist.
@@ -25,9 +26,9 @@ trait HoistUser implements JSONFormat {
     abstract String getEmail()
 
     /**
-     * Username for the user.
-     * Used for authentication, logging, tracking, and as a key for data storage of preferences and user state.
-     * Apps must ensure each username is a unique String and that HoistUser.validateUsername(username) == true.
+     * Username for the user. Used for authentication, logging, tracking, and as a key for data
+     * storage of preferences and user state. Apps must ensure each username is a unique to the
+     * organization and that HoistUser.validateUsername(username) == true.
      */
     abstract String getUsername()
 
@@ -35,13 +36,39 @@ trait HoistUser implements JSONFormat {
         return username
     }
 
+    /**
+     * Roles are the primary source of application-level permissions and access.
+     *
+     * They are validated against server-side @Access interceptors to secure endpoints and are
+     * serialized to JS clients for use in client-side logic.
+     */
     Set<String> getRoles()  {
-        return Collections.emptySet()
+        return roleService.getRolesForUser(username)
     }
 
+    boolean hasRole(String role)  {
+        return roles.contains(role)
+    }
+
+    boolean hasAllRoles(String[] requiredRoles) {
+        return roles.containsAll(requiredRoles)
+    }
+
+    /**
+     * Gates are a lighter-weight concept, similar to roles, but sourced here from soft-config
+     * and intended to restrict access to features under development or pending review.
+     */
     boolean hasGate(String gate) {
         List gateUsers = configService.getStringList(gate)
         gateUsers.contains('*') || gateUsers.contains(username)
+    }
+
+    boolean equals(Object other) {
+        return other && other instanceof HoistUser && other.username == username
+    }
+
+    int hashCode() {
+        return username.hashCode()
     }
 
     Map formatForJSON() {
@@ -49,7 +76,6 @@ trait HoistUser implements JSONFormat {
                 username: username,
                 email: email,
                 displayName: displayName,
-                roles: roles,
                 active: active
         ]
     }

--- a/src/main/groovy/io/xh/hoist/user/HoistUser.groovy
+++ b/src/main/groovy/io/xh/hoist/user/HoistUser.groovy
@@ -63,13 +63,13 @@ trait HoistUser implements JSONFormat {
         gateUsers.contains('*') || gateUsers.contains(username)
     }
 
+    String toString() {username}
+
     boolean equals(Object other) {
-        return other && other instanceof HoistUser && other.username == username
+        other instanceof HoistUser && Objects.equals(other.username, username)
     }
 
-    int hashCode() {
-        return username.hashCode()
-    }
+    int hashCode() {Objects.hashCode(username)}
 
     Map formatForJSON() {
         return [

--- a/src/main/groovy/io/xh/hoist/util/Utils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/Utils.groovy
@@ -14,6 +14,8 @@ import io.xh.hoist.config.ConfigService
 import io.xh.hoist.json.JSON
 import io.xh.hoist.pref.PrefService
 import io.xh.hoist.track.TrackLog
+import io.xh.hoist.user.BaseRoleService
+import io.xh.hoist.user.BaseUserService
 import org.grails.web.converters.exceptions.ConverterException
 import org.grails.web.json.JSONArray
 import org.grails.web.json.JSONObject
@@ -62,6 +64,14 @@ class Utils {
 
     static PrefService getPrefService() {
         return (PrefService) appContext.prefService
+    }
+
+    static BaseUserService getUserService() {
+        return (BaseUserService) appContext.userService
+    }
+
+    static BaseRoleService getRoleService() {
+        return (BaseRoleService) appContext.roleService
     }
 
     static ApplicationContext getAppContext() {


### PR DESCRIPTION
+ Identity service caches only username strings in session, delegates to UserService to resolve to HoistUser objects.
+ New requirement for apps to implement a RoleService (over new BaseRoleService), called by HoistUser to produce role assignments on demand and to avoid caching in the user object.
+ HoistUser no longer serializes roles in its JSONFormat to aid more efficient use of this object as a general class for data on enterprise users (which might or might not have app-level roles).
+ Methods added to BaseAuthenticationService to reduce app-level boilerplate, including revised stubs for login/logout + resource whitelisting.
+ Server <> Client API changes around checking for initial auth status.
+ Rename `HoistImplController` -> `XhController` for more consistent use of `XH` as private/implementation namespace, easier to type URLs for debugging.