### PR TITLE
InstanceConfigUtils checks for [appCode].yml within specified directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * `JSONClient` can be constructed without providing a configured `ClosableHttpClient`. A default
   client will be created and used.
+* When pointed to a directory, `InstanceConfigUtils` will first check to see if it contains a file
+  named `[appCode].yml` and, if so, will load configs from that single file and return. Otherwise,
+  individual files within that directory will be loaded as key/value pairs, as they were previously.
+  This allows a single `-Dio.xh.hoist.instanceConfigFile` value to be baked into a container build
+  and resolve to either single-file or directory-mode configs based on the deployment environment.
 
 ## 6.2.0 - 2019-08-13
 

--- a/src/main/groovy/io/xh/hoist/util/InstanceConfigUtils.groovy
+++ b/src/main/groovy/io/xh/hoist/util/InstanceConfigUtils.groovy
@@ -12,24 +12,38 @@ import org.yaml.snakeyaml.Yaml
 
 /**
  * Utility for loading optional, file-based configuration properties once on startup and exposing
- * them to the application as a map. This utility can be pointed to one of two kinds of files:
- *
- *      + A single YAML (.yml) file containing key value pairs (the default).
- *
- *      + A directory containing multiple files, where the file names are the keys and the
- *        file contents are the values. This is intended for use in a Docker environment with
- *        configs/secrets mounted to a local path within the container.
- *
- * To support this second form, all values will be read in and provided as Strings.
+ * them to the application as a map.
  *
  * These are intended to be minimal, low-level configs that apply to a particular deployed instance
  * of the application and therefore are better sourced from a local file/volume vs. source code,
- * JavaOpts, or database-driven ConfigService entries. Expected use-cases include configs for the
- * primary database connection itself (e.g. host/username/password).
+ * JavaOpts, or database-driven ConfigService entries.
+ *
+ * They are also typically used to provide the connection information and credentials for the
+ * primary database connection itself, keeping that sensitive info out of the source code.
+ *
+ * This utility will consult the `-Dio.xh.hoist.instanceConfigFile` JavaOpt for the full path to one
+ * of the following supported locations:
+ *
+ *      1) A YAML (.yml) file containing key value pairs.
+ *      2) A directory containing multiple files, where the file names are loaded as config keys and
+ *          their contents are read in as the values.
+ *      3) A directory containing a YAML file with the name [appCode].yml.
+ *
+ * Option (1) is the default if the JavaOpt is not set, with a default location of
+ * /etc/hoist/conf/[appCode].yml.
+ *
+ * Option (2) is intended for use in a Docker environment with configs/secrets mounted to a local
+ * path within the container. (This is how Docker exposes configs to the runtime environment.)
+ *
+ * Option (3) is intended for builds that might or might not be deployed within Docker - allowing
+ * for a single "directory style" JavaOpt value to be baked into the Tomcat container and resolve to
+ * either a single file or to a directory of Docker configs.
+ *
+ * Note that all values will be read in and provided as Strings.
  *
  * This utility also establishes the `AppEnvironment`, sourcing it from (in priority order):
  *
- *      1) -Dio.xh.hoist.environment JavaOpt, if provided.
+ *      1) A `-Dio.xh.hoist.environment` JavaOpt, if provided.
  *      2) Config file/directory entry with key `environment`, if provided.
  *      3) Fallback to Development, if not otherwise specified.
  *
@@ -41,9 +55,6 @@ import org.yaml.snakeyaml.Yaml
  * and processed prior to compilation. It can however be read from within a conf/runtime.groovy
  * file, which can also be used to set core Grails configuration options (as long as they are not
  * needed for any CLI commands you are using). See https://docs.grails.org/latest/guide/conf.html
- *
- * The location of the config file itself is specified via a -Dio.xh.hoist.instanceConfigFile
- * JavaOpt (if the default path below is not satisfactory).
  */
 class InstanceConfigUtils {
 
@@ -92,17 +103,37 @@ class InstanceConfigUtils {
     }
 
     private static Map<String, String> loadFromConfigDir(File configDirectory) {
-        def ret = [:]
+        File yamlFile = null
+        Collection<File> configFiles = []
+        String appCodeFilename = "${Utils.appCode}.yml"
+
         configDirectory.listFiles().each{File it ->
-            if (it.canRead() && !it.isDirectory()) {
-                ret[it.name] = it.text.trim()
+            if (!it.canRead() || it.isDirectory()) return
+            if (it.name == appCodeFilename) {
+                yamlFile = it
+            } else {
+                configFiles << it
             }
+        }
+
+        def ret
+        if (yamlFile) {
+            ret = loadFromYaml(yamlFile)
+        } else {
+            ret = configFiles.collectEntries{[it.name, it.text.trim()]} as Map<String, String>
+            logLoadCount(ret, configDirectory)
         }
         return ret
     }
 
     private static Map<String, String> loadFromYaml(File configFile) {
-        return new Yaml().loadAs(configFile.newInputStream(), Map)
+        def ret = new Yaml().loadAs(configFile.newInputStream(), Map)
+        logLoadCount(ret, configFile)
+        return ret
+    }
+
+    private static void logLoadCount(Map configs, File configFile) {
+        println "Loaded ${configs.size()} instanceConfigs from ${configFile.getAbsolutePath()}"
     }
 
 }


### PR DESCRIPTION
Paul and I discussed this in the context of a client app where we might well have a mixed-environment between Rancher and non-Rancher deployments.

We currently bake the JavaOpt value pointing to the instanceConfig path into the Tomcat container. We would like to be able to deploy the same container build in either environment, so we needed to make `InstanceConfigUtils` a bit more flexible and allow it to be pointed at a directory and expect to find either an `[appCode].yml` file or a collection of config files.